### PR TITLE
feat: use path in name

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
 import { rm, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { consola } from 'consola'
@@ -206,6 +206,7 @@ async function generateTransparentAssets(
     }
 
     filePath = resolveTempPngAssetName(filePath)
+    checkGenerateFolder(filePath)
     const { width, height } = extractAssetSize(size, padding)
     await sharp({
       create: {
@@ -249,6 +250,7 @@ async function generateMaskableAssets(
     }
 
     filePath = resolveTempPngAssetName(filePath)
+    checkGenerateFolder(filePath)
     const { width, height } = extractAssetSize(size, padding)
     await sharp({
       create: {
@@ -375,6 +377,7 @@ async function generateAppleSplashScreens(
     }
 
     filePath = resolveTempPngAssetName(filePath)
+    checkGenerateFolder(filePath)
     const { width, height } = extractAppleDeviceSize(size.size, size.padding)
     await sharp({
       create: {
@@ -407,4 +410,10 @@ async function generateAppleSplashScreens(
       }
     }
   }))
+}
+
+function checkGenerateFolder(filePath: string) {
+  const generateFolder = dirname(filePath)
+  if (!existsSync(generateFolder))
+    mkdirSync(generateFolder, { recursive: true })
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -184,7 +184,8 @@ async function optimizePng(filePath: string, png: PngOptions) {
   }
 }
 
-function resolveTempPngAssetName(name: string) {
+async function resolveTempPngAssetName(name: string) {
+  await mkdirSync(dirname(name), { recursive: true })
   return name.replace(/\.png$/, '-temp.png')
 }
 
@@ -205,8 +206,7 @@ async function generateTransparentAssets(
       return
     }
 
-    filePath = resolveTempPngAssetName(filePath)
-    checkGenerateFolder(filePath)
+    filePath = await resolveTempPngAssetName(filePath)
     const { width, height } = extractAssetSize(size, padding)
     await sharp({
       create: {
@@ -249,8 +249,7 @@ async function generateMaskableAssets(
       return
     }
 
-    filePath = resolveTempPngAssetName(filePath)
-    checkGenerateFolder(filePath)
+    filePath = await resolveTempPngAssetName(filePath)
     const { width, height } = extractAssetSize(size, padding)
     await sharp({
       create: {
@@ -376,8 +375,7 @@ async function generateAppleSplashScreens(
       return
     }
 
-    filePath = resolveTempPngAssetName(filePath)
-    checkGenerateFolder(filePath)
+    filePath = await resolveTempPngAssetName(filePath)
     const { width, height } = extractAppleDeviceSize(size.size, size.padding)
     await sharp({
       create: {
@@ -410,10 +408,4 @@ async function generateAppleSplashScreens(
       }
     }
   }))
-}
-
-function checkGenerateFolder(filePath: string) {
-  const generateFolder = dirname(filePath)
-  if (!existsSync(generateFolder))
-    mkdirSync(generateFolder, { recursive: true })
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync } from 'node:fs'
-import { rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { consola } from 'consola'
 import { green, yellow } from 'colorette'
@@ -185,7 +185,7 @@ async function optimizePng(filePath: string, png: PngOptions) {
 }
 
 async function resolveTempPngAssetName(name: string) {
-  await mkdirSync(dirname(name), { recursive: true })
+  await mkdir(dirname(name), { recursive: true })
   return name.replace(/\.png$/, '-temp.png')
 }
 


### PR DESCRIPTION
I want to define static resource generate path, but it's need to mkdir.
```js
  preset: {
    transparent: {
      sizes: [64, 192, 512],
      favicons: [[48, 'favicon-48x48.ico'], [64, 'favicon.ico']],
    },
    maskable: {
      sizes: [512],
    },
    apple: {
      sizes: [180],
    },

    // define icons generate path
    assetName: (type: AssetType, size: ResolvedAssetSize) => `static/icons/${defaultAssetName(type, size)}`,

    appleSplashScreens: createAppleSplashScreens({
      name: (landscape, size, dark) => {
        // define splash-screens generate path
        return `static/splash-screens/apple-splash-${landscape ? 'landscape' : 'portrait'}-${typeof dark === 'boolean' ? (dark ? 'dark-' : 'light-') : ''}${size.width}x${size.height}.png`
      },
    }, ['iPad Air 9.7"']),
  },
```