### PR TITLE
feat(splash): set default fit to 'contain' for resize options

### DIFF
--- a/src/cli-start.ts
+++ b/src/cli-start.ts
@@ -6,6 +6,7 @@ import { defaultSplashScreenName, loadConfig } from './config.ts'
 import type { BuiltInPreset, Preset, ResolvedAppleSplashScreens, ResolvedAssets, UserConfig } from './config.ts'
 import { defaultAssetName, defaultPngCompressionOptions, toResolvedAsset } from './utils.ts'
 import { generatePWAAssets } from './build.ts'
+import {PngOptions, ResizeOptions} from "sharp";
 
 interface CliOptions extends Omit<UserConfig, 'preset' | 'images'> {
   preset?: BuiltInPreset
@@ -77,19 +78,28 @@ async function run(images: string[] = [], cliOptions: CliOptions = {}) {
 
   let appleSplashScreens: ResolvedAppleSplashScreens | undefined
   if (useAppleSplashScreens) {
-    let {
+    const {
       padding = 0.3,
-      resizeOptions,
-      darkResizeOptions,
+      resizeOptions: useResizeOptions = {},
+      darkResizeOptions: useDarkResizeOptions = {},
       linkMediaOptions: useLinkMediaOptions = {},
       sizes,
       name = defaultSplashScreenName,
-      png = { compressionLevel: 9, quality: 60 },
+      png: usePng = {},
     } = useAppleSplashScreens
 
-    // Set default fit to contain
-    resizeOptions = { fit: 'contain', ...{ resizeOptions } }
-    darkResizeOptions = { fit: 'contain', ...{ darkResizeOptions } }
+    // Initialize defaults
+    const resizeOptions: ResizeOptions = {
+      fit: 'contain',
+      background: 'white',
+      ...useResizeOptions
+    }
+    const darkResizeOptions: ResizeOptions = {
+      fit: 'contain',
+      background: 'black',
+      ...useDarkResizeOptions
+    }
+    const png: PngOptions = { compressionLevel: 9, quality: 60, ...usePng }
 
     sizes.forEach((size) => {
       if (typeof size.padding === 'undefined')

--- a/src/cli-start.ts
+++ b/src/cli-start.ts
@@ -1,12 +1,12 @@
 import cac from 'cac'
 import { consola } from 'consola'
 import { green } from 'colorette'
+import type { PngOptions, ResizeOptions } from 'sharp'
 import { version } from '../package.json'
 import { defaultSplashScreenName, loadConfig } from './config.ts'
 import type { BuiltInPreset, Preset, ResolvedAppleSplashScreens, ResolvedAssets, UserConfig } from './config.ts'
 import { defaultAssetName, defaultPngCompressionOptions, toResolvedAsset } from './utils.ts'
 import { generatePWAAssets } from './build.ts'
-import {PngOptions, ResizeOptions} from "sharp";
 
 interface CliOptions extends Omit<UserConfig, 'preset' | 'images'> {
   preset?: BuiltInPreset
@@ -92,12 +92,12 @@ async function run(images: string[] = [], cliOptions: CliOptions = {}) {
     const resizeOptions: ResizeOptions = {
       fit: 'contain',
       background: 'white',
-      ...useResizeOptions
+      ...useResizeOptions,
     }
     const darkResizeOptions: ResizeOptions = {
       fit: 'contain',
       background: 'black',
-      ...useDarkResizeOptions
+      ...useDarkResizeOptions,
     }
     const png: PngOptions = { compressionLevel: 9, quality: 60, ...usePng }
 

--- a/src/cli-start.ts
+++ b/src/cli-start.ts
@@ -77,7 +77,7 @@ async function run(images: string[] = [], cliOptions: CliOptions = {}) {
 
   let appleSplashScreens: ResolvedAppleSplashScreens | undefined
   if (useAppleSplashScreens) {
-    const {
+    let {
       padding = 0.3,
       resizeOptions,
       darkResizeOptions,
@@ -86,6 +86,11 @@ async function run(images: string[] = [], cliOptions: CliOptions = {}) {
       name = defaultSplashScreenName,
       png = { compressionLevel: 9, quality: 60 },
     } = useAppleSplashScreens
+
+    // Set default fit to contain
+    resizeOptions = { fit: 'contain', ...{ resizeOptions } }
+    darkResizeOptions = { fit: 'contain', ...{ darkResizeOptions } }
+
     sizes.forEach((size) => {
       if (typeof size.padding === 'undefined')
         size.padding = padding


### PR DESCRIPTION
https://github.com/vite-pwa/docs/pull/81

fixes #16 