### PR TITLE
fix: apple dark splash screens always generated

### DIFF
--- a/playground/pwa-assets.config.mts
+++ b/playground/pwa-assets.config.mts
@@ -9,7 +9,8 @@ export default defineConfig({
     appleSplashScreens: createAppleSplashScreens({
       padding: 0.3,
       resizeOptions: { fit: 'contain', background: 'white' },
-      darkResizeOptions: { fit: 'contain', background: 'black' },
+      // to test issue #28
+      //darkResizeOptions: { fit: 'contain', background: 'black' },
       linkMediaOptions: {
         log: true,
         addMediaScreen: true,

--- a/src/api/apple-icons-helper.ts
+++ b/src/api/apple-icons-helper.ts
@@ -154,7 +154,7 @@ function resolveAppleSplashScreens(
     const {
       padding = 0.3,
       resizeOptions: useResizeOptions = {},
-      darkResizeOptions: useDarkResizeOptions = {},
+      darkResizeOptions: useDarkResizeOptions,
       linkMediaOptions: useLinkMediaOptions = {},
       sizes,
       name = defaultSplashScreenName,
@@ -163,7 +163,7 @@ function resolveAppleSplashScreens(
 
     // Initialize defaults
     const resizeOptions = createResizeOptions(false, useResizeOptions)
-    const darkResizeOptions = createResizeOptions(true, useDarkResizeOptions)
+    const darkResizeOptions = useDarkResizeOptions ? createResizeOptions(true, useDarkResizeOptions) : undefined
     const png: PngOptions = createPngCompressionOptions(usePng)
 
     for (const size of sizes) {
@@ -176,7 +176,7 @@ function resolveAppleSplashScreens(
       if (typeof size.resizeOptions === 'undefined')
         size.resizeOptions = resizeOptions
 
-      if (typeof size.darkResizeOptions === 'undefined')
+      if (typeof size.darkResizeOptions === 'undefined' && darkResizeOptions)
         size.darkResizeOptions = darkResizeOptions
     }
     const {


### PR DESCRIPTION
The dark resize options being initialized if missing in the user configuration

closes #28