### PR TITLE
fix(manifest): fix icon src to absolute path when manifest is not a t…

### DIFF
--- a/src/api/generate-manifest-icons-entry.ts
+++ b/src/api/generate-manifest-icons-entry.ts
@@ -8,14 +8,14 @@ export function generateManifestIconsEntry<Format extends ManifestIconsType>(
 
   for (const icon of Object.values(instruction.transparent)) {
     icons.icons.push({
-      src: icon.name,
+      src: icon.url,
       sizes: `${icon.width}x${icon.height}`,
       type: icon.mimeType,
     })
   }
   for (const icon of Object.values(instruction.maskable)) {
     icons.icons.push({
-      src: icon.name,
+      src: icon.url,
       sizes: `${icon.width}x${icon.height}`,
       type: icon.mimeType,
       purpose: 'maskable',


### PR DESCRIPTION
…he root

### Description

When building manifest entries with a basePath different from root, icons src are relative instead of absolute, which prevent the browser to load the correct file. src field should be set from icon url and not icon name.

### Linked Issues

fixes #59 

### Additional Context
